### PR TITLE
[feat] 스웨거에서 토큰으로 테스트 가능하게 만듦

### DIFF
--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/config/SwaggerConfig.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.kernel360.ronaldo.TemuOverflow.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("accessToken", new SecurityScheme()
+                                .name("Authorization") // 헤더 이름
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                        )
+                )
+                .addSecurityItem(new SecurityRequirement().addList("accessToken")) // 요청에 SecurityScheme 적용
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("테무오버플로우")
+                .description("테무오버플로우 API 명세서")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/user/controller/UserAuthController.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/user/controller/UserAuthController.java
@@ -3,6 +3,11 @@ package com.kernel360.ronaldo.TemuOverflow.user.controller;
 import com.kernel360.ronaldo.TemuOverflow.user.dto.UserSignUpRequest;
 import com.kernel360.ronaldo.TemuOverflow.user.entity.User;
 import com.kernel360.ronaldo.TemuOverflow.user.service.UserAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +32,23 @@ public class UserAuthController {
         UserSignUpRequest userSignUpRequest = new UserSignUpRequest(email, password, nickname, profileImage);
         User user = userAuthService.signUp(userSignUpRequest);
         return ResponseEntity.ok(user);
+    }
+
+    @Operation(summary = "일반 로그인 (로그인 요청을 통해 JWT 토큰을 발급받음)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일반 로그인 성공(반환 문자열 없음. 헤더에 토큰 반환)", content = @Content(mediaType = "application/json", schema = @Schema(example = "{\n  \"message\": \"유저의 ROLE이 GUEST이므로 온보딩API를 호출해 온보딩을 진행해야합니다.\", \"role\": \"GUEST\"}"))),
+            @ApiResponse(responseCode = "4XX", description = "일반 로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(example = "실패 메세지(정확히 어떤 메세지인지는 모름)")))
+    })
+    @PostMapping("/login")
+    public String login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "로그인 요청 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(type = "object", example = "{\"email\": \"user@example.com\", \"password\": \"password1234\"}")
+                    )
+            )
+            @RequestBody Map<String, String> loginRequest) {
+        return "로그인 성공"; // 실제 로그인 처리는 Security 필터에서 수행
     }
 }


### PR DESCRIPTION
## 작성한 코드
- 스웨거에서 엑세스 토큰 발급 받아서 테스트 가능하게 코드 수정하였습니다.

## 확인해야할 사항
- 스웨거에서 로그인 api 호출했을 때 유효한 email, password이면 헤더에 Authorization으로 엑세스 토큰이 발급될 것임.
- 발급받은 엑세스 토큰을 스웨거의 우측 상단 Authorize에 넣고 원하는 api에 요청을 보내면 엑세스 토큰이 유효하면 요청이 보내질 것이고, 유효하지 않으면 토큰 비유효 응답이 올 것임

## 테스트 결과
### 토큰 비유효시 응답
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/f4f868a5-a550-4bf5-a8bb-386511ddedab" />

### 토큰 유효시 응답
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/a5d71968-8807-4d1b-927d-a92a810e6339" />
