### PR TITLE
[Feat] 게시글 좋아요, 댓글 좋아요 기능 완성

### DIFF
--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/service/LikeService.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/service/LikeService.java
@@ -8,6 +8,8 @@ import com.kernel360.ronaldo.TemuOverflow.Like.entity.LikeReply;
 import com.kernel360.ronaldo.TemuOverflow.Like.repository.LikeArticleRepository;
 import com.kernel360.ronaldo.TemuOverflow.Like.repository.LikeReplyRepository;
 import com.kernel360.ronaldo.TemuOverflow.post.repository.PostRepository;
+import com.kernel360.ronaldo.TemuOverflow.reply.repository.ReplyRepository;
+import com.kernel360.ronaldo.TemuOverflow.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +21,7 @@ public class LikeService {
     private final LikeArticleRepository likeArticleRepository;
     private final LikeReplyRepository likeReplyRepository;
     private final PostRepository postRepository;
+    private final ReplyRepository replyRepository;
 
     public LikeArticleResponse likeArticle(Long userId, LikeRequest likeArticleRequest) {
         Long articleId = likeArticleRequest.getObjectId();
@@ -50,7 +53,7 @@ public class LikeService {
     public LikeReplyResponse likeReply(Long userId, LikeRequest likeReplyRequest) {
         Long replyId = likeReplyRequest.getObjectId();
 
-        boolean replyExists = postRepository.existsById(replyId);
+        boolean replyExists = replyRepository.existsById(replyId);
         if (!replyExists) {
             throw new IllegalArgumentException("존재하지 않는 댓글입니다.");
         }


### PR DESCRIPTION
## 작성한 코드
- 게시글 좋아요, 댓글 좋아요 기능 완성

## 구현한 기능
- 특정 사용자가 게시글과 댓글에 좋아요를 누를 수 있음
- 이미 좋아요를 누른 게시글이나 댓글이면 더 좋아요가 불가능함.
- 이미 좋아요를 누른 게시글이나 댓글에 좋아요 요청을 보내면 좋아요가 취소됨.

Closed #23 