### PR TITLE
[Mod] create_at, update_at 서버에서 자동으로 설정되게 수정 / 좋아요 수 반환되게 수정 / DTO 변경

### DIFF
--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeArticle.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeArticle.java
@@ -17,8 +17,6 @@ public class LikeArticle {
     @Column
     private Long id;
 
-    private Long articleId;
-
     private Long userId;
 
     @ManyToOne

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeArticle.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeArticle.java
@@ -1,9 +1,8 @@
 package com.kernel360.ronaldo.TemuOverflow.Like.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.kernel360.ronaldo.TemuOverflow.post.entity.Post;
+import com.kernel360.ronaldo.TemuOverflow.reply.entity.Reply;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -21,4 +20,8 @@ public class LikeArticle {
     private Long articleId;
 
     private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeReply.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeReply.java
@@ -1,9 +1,7 @@
 package com.kernel360.ronaldo.TemuOverflow.Like.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import com.kernel360.ronaldo.TemuOverflow.reply.entity.Reply;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -21,4 +19,8 @@ public class LikeReply {
     private Long replyId;
 
     private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "reply_id", nullable = false)
+    private Reply reply;
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeReply.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/entity/LikeReply.java
@@ -16,8 +16,6 @@ public class LikeReply {
     @Column
     private Long id;
 
-    private Long replyId;
-
     private Long userId;
 
     @ManyToOne

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/repository/LikeArticleRepository.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/repository/LikeArticleRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface LikeArticleRepository extends JpaRepository<LikeArticle, Long> {
-    Optional<LikeArticle> findByArticleIdAndUserId(Long articleId, Long userId);
+    Optional<LikeArticle> findByPostIdAndUserId(Long articleId, Long userId);
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/repository/LikeReplyRepository.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/repository/LikeReplyRepository.java
@@ -2,9 +2,11 @@ package com.kernel360.ronaldo.TemuOverflow.Like.repository;
 
 import com.kernel360.ronaldo.TemuOverflow.Like.entity.LikeReply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface LikeReplyRepository extends JpaRepository<LikeReply, Long> {
 
     Optional<LikeReply> findByReplyIdAndUserId(Long replyId, Long userId);

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/service/LikeService.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/Like/service/LikeService.java
@@ -32,7 +32,7 @@ public class LikeService {
         }
 
         // 사용자가 이미 해당 게시글에 좋아요를 눌렀는지 확인
-        Optional<LikeArticle> existingLike = likeArticleRepository.findByArticleIdAndUserId(articleId, userId);
+        Optional<LikeArticle> existingLike = likeArticleRepository.findByPostIdAndUserId(articleId, userId);
 
         if (existingLike.isPresent()) {
             // 이미 좋아요를 눌렀다면 좋아요 취소
@@ -42,7 +42,7 @@ public class LikeService {
 
         // 좋아요 저장
         LikeArticle likeArticle = LikeArticle.builder()
-                .articleId(articleId)
+                .post(postRepository.findById(articleId).get())
                 .userId(userId)
                 .build();
         likeArticleRepository.save(likeArticle);
@@ -69,7 +69,7 @@ public class LikeService {
 
         // 좋아요 저장
         LikeReply likeReply = LikeReply.builder()
-                .replyId(replyId)
+                .reply(replyRepository.findById(replyId).get())
                 .userId(userId)
                 .build();
         likeReplyRepository.save(likeReply);

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/controller/PostController.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/controller/PostController.java
@@ -1,6 +1,9 @@
 package com.kernel360.ronaldo.TemuOverflow.post.controller;
 
+import com.kernel360.ronaldo.TemuOverflow.post.dto.CreatePostRequest;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.CreatePostResponse;
 import com.kernel360.ronaldo.TemuOverflow.post.dto.PostDto;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.UpdatePostRequest;
 import com.kernel360.ronaldo.TemuOverflow.post.entity.Post;
 import com.kernel360.ronaldo.TemuOverflow.post.service.PostService;
 import com.kernel360.ronaldo.TemuOverflow.user.service.UserAuthService;
@@ -23,9 +26,10 @@ public class PostController {
 
     // 게시글 생성 (POST)
     @PostMapping
-    public ResponseEntity<PostDto> createPost(@RequestBody PostDto postDto) {
-        Post post = postService.createPost(postDto.toEntity());
-        return new ResponseEntity<>(PostDto.fromEntity(post), HttpStatus.CREATED);
+    public ResponseEntity<PostDto> createPost(HttpServletRequest request, @RequestBody CreatePostRequest createPostRequest) {
+        Long userId = userAuthService.getUserIdFromToken(request);
+        PostDto postDto = postService.createPost(userId, createPostRequest);
+        return new ResponseEntity<>(postDto, HttpStatus.CREATED);
     }
 
     // 전체 게시글 조회 (GET)
@@ -46,9 +50,9 @@ public class PostController {
 
     // 게시글 수정 (PUT)
     @PutMapping("/{id}")
-    public ResponseEntity<PostDto> updatePost(@PathVariable Long id, @RequestBody PostDto postDto) {
-        Post post = postService.updatePost(id, postDto.toEntity());
-        return ResponseEntity.ok(PostDto.fromEntity(post));
+    public ResponseEntity<PostDto> updatePost(@PathVariable Long id, @RequestBody UpdatePostRequest updatePostRequest) {
+        PostDto postDto = postService.updatePost(id, updatePostRequest);
+        return ResponseEntity.ok(postDto);
     }
 
     // 게시글 삭제 (DELETE)

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/CreatePostRequest.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/CreatePostRequest.java
@@ -1,0 +1,17 @@
+package com.kernel360.ronaldo.TemuOverflow.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePostRequest {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/CreatePostResponse.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/CreatePostResponse.java
@@ -1,0 +1,13 @@
+package com.kernel360.ronaldo.TemuOverflow.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreatePostResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private Long userId;
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/PostDto.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/PostDto.java
@@ -19,8 +19,9 @@ public class PostDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private Boolean isSolved;
-    private String category;
+    private int likeCount;
+//    private boolean isSolved;
+//    private String category;
 
 
     // 데이터베이스에서 조회한 엔티티를 클라이언트에 반환할때 사용
@@ -31,23 +32,24 @@ public class PostDto {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .createdAt(post.getCreatedAt())
-                .updatedAt(post.getUpdatedAt())
-                .isSolved(post.getIsSolved())
-                .category(post.getCategory())
+                .updatedAt(post.getUpdatedAt() == null ? LocalDateTime.MIN : post.getUpdatedAt())
+                .likeCount(post.getLikeCount())
+//                .isSolved(post.getIsSolved() == null ? false : post.getIsSolved())
+//                .category(post.getCategory() == null ? "null" : post.getCategory())
                 .build();
     }
-
-    // 클라이언트에서 받은 DTO를 데이터베이스에 저장할때 사용
-    public Post toEntity() {
-        return Post.builder()
-                .id(this.id)
-                .userId(this.userId)
-                .title(this.title)
-                .content(this.content)
-                .createdAt(this.createdAt)
-                .updatedAt(this.updatedAt)
-                .isSolved(this.isSolved)
-                .category(this.category)
-                .build();
-    }
+//
+//    // 클라이언트에서 받은 DTO를 데이터베이스에 저장할때 사용
+//    public Post toEntity() {
+//        return Post.builder()
+//                .id(this.id)
+//                .userId(this.userId)
+//                .title(this.title)
+//                .content(this.content)
+//                .createdAt(this.createdAt)
+//                .updatedAt(this.updatedAt)
+//                .isSolved(this.isSolved)
+//                .category(this.category)
+//                .build();
+//    }
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/UpdatePostRequest.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/dto/UpdatePostRequest.java
@@ -1,0 +1,15 @@
+package com.kernel360.ronaldo.TemuOverflow.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePostRequest {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/entity/Post.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/entity/Post.java
@@ -48,6 +48,6 @@ public class Post {
 
     // 좋아요 개수를 반환하는 메서드
     public int getLikeCount() {
-        return likeArticles.size();
+        return likeArticles ==null ? 0 : likeArticles.size();
     }
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/entity/Post.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/entity/Post.java
@@ -1,16 +1,18 @@
 package com.kernel360.ronaldo.TemuOverflow.post.entity;
 
+import com.kernel360.ronaldo.TemuOverflow.Like.entity.LikeArticle;
+import com.kernel360.ronaldo.TemuOverflow.Like.entity.LikeReply;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "post")
-@Data
+@Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -20,13 +22,13 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
+    @Column(name = "user_id")
     private Long userId;
 
     @Column(nullable = false, length = 45)
     private String title;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(name = "created_at", updatable = false)
@@ -38,6 +40,14 @@ public class Post {
     @Column(name = "is_solved")
     private Boolean isSolved = false;
 
-    @Column(nullable = false, length = 45)
+    @Column(length = 45)
     private String category;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LikeArticle> likeArticles = new ArrayList<>();
+
+    // 좋아요 개수를 반환하는 메서드
+    public int getLikeCount() {
+        return likeArticles.size();
+    }
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/repository/PostRepository.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/repository/PostRepository.java
@@ -4,9 +4,11 @@ import com.kernel360.ronaldo.TemuOverflow.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/service/PostService.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/service/PostService.java
@@ -1,11 +1,18 @@
 package com.kernel360.ronaldo.TemuOverflow.post.service;
 
+import com.amazonaws.services.kms.model.CreateAliasRequest;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.CreatePostRequest;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.CreatePostResponse;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.PostDto;
+import com.kernel360.ronaldo.TemuOverflow.post.dto.UpdatePostRequest;
 import com.kernel360.ronaldo.TemuOverflow.post.entity.Post;
 import com.kernel360.ronaldo.TemuOverflow.post.repository.PostRepository;
 import com.kernel360.ronaldo.TemuOverflow.user.service.UserAuthService;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.sql.Update;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -16,8 +23,15 @@ public class PostService {
     private final UserAuthService userAuthService;
 
     // 게시글 생성
-    public Post createPost(Post post) {
-        return postRepository.save(post);
+    public PostDto createPost(Long userId, CreatePostRequest createPostRequest) {
+        Post post = Post.builder()
+                .userId(userId)
+                .title(createPostRequest.getTitle())
+                .content(createPostRequest.getContent())
+                .createdAt(LocalDateTime.now())
+                .build();
+        postRepository.save(post);
+        return PostDto.fromEntity(post);
     }
 
     // 전체 게시글 조회
@@ -31,14 +45,15 @@ public class PostService {
     }
 
     // 게시글 수정
-    public Post updatePost(Long id, Post updatedPost) {
+    public PostDto updatePost(Long id, UpdatePostRequest updatePostRequest) {
         Post post = getPostById(id);
-        post.setTitle(updatedPost.getTitle());
-        post.setContent(updatedPost.getContent());
-        post.setCategory(updatedPost.getCategory());
-        post.setIsSolved(updatedPost.getIsSolved());
-        post.setUpdatedAt(updatedPost.getUpdatedAt());
-        return postRepository.save(post);
+        post.setTitle(updatePostRequest.getTitle());
+        post.setContent(updatePostRequest.getContent());
+        post.setUpdatedAt(LocalDateTime.now());
+//        post.setCategory(updatedPost.getCategory());
+//        post.setIsSolved(updatedPost.getIsSolved());
+        postRepository.save(post);
+        return PostDto.fromEntity(post);
     }
 
     // 게시글 삭제

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/CreateReplyRequest.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/CreateReplyRequest.java
@@ -1,0 +1,11 @@
+package com.kernel360.ronaldo.TemuOverflow.reply.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateReplyRequest {
+    private String content;
+    private Long postId;
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/ReplyDto.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/ReplyDto.java
@@ -21,7 +21,7 @@ ReplyDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private String content;
-    private int like;
+    private int likeCount;
 
 
     // 데이터베이스에서 조회한 엔티티를 클라이언트에 반환할때 사용
@@ -31,17 +31,20 @@ ReplyDto {
                 .postId(reply.getPostId())
                 .userId(reply.getUserId())
                 .content(reply.getContent())
+                .createdAt(reply.getCreatedAt())
+                .updatedAt(reply.getUpdatedAt() == null ? LocalDateTime.MIN : reply.getUpdatedAt())
+                .likeCount(reply.getLikeCount())
                 .build();
     }
 
-    // 클라이언트에서 받은 DTO를 데이터베이스에 저장할때 사용
-    public Reply toEntity() {
-        return Reply.builder()
-                .id(this.id)
-                .postId(this.postId)
-                .userId(this.userId)
-                .content(this.content)
-                .build();
-    }
+//    // 클라이언트에서 받은 DTO를 데이터베이스에 저장할때 사용
+//    public Reply toEntity() {
+//        return Reply.builder()
+//                .id(this.id)
+//                .postId(this.postId)
+//                .userId(this.userId)
+//                .content(this.content)
+//                .build();
+//    }
 
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/UpdateReplyRequest.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/dto/UpdateReplyRequest.java
@@ -1,0 +1,10 @@
+package com.kernel360.ronaldo.TemuOverflow.reply.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UpdateReplyRequest {
+    private String content;
+}

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/entity/Reply.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/entity/Reply.java
@@ -45,7 +45,7 @@ public class Reply {
 
     // 좋아요 개수를 반환하는 메서드
     public int getLikeCount() {
-        return likeReplies.size();
+        return likeReplies == null ? 0 : likeReplies.size();
     }
 
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/entity/Reply.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/entity/Reply.java
@@ -1,11 +1,14 @@
 package com.kernel360.ronaldo.TemuOverflow.reply.entity;
 
+import com.kernel360.ronaldo.TemuOverflow.Like.entity.LikeReply;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "reply")
@@ -37,8 +40,12 @@ public class Reply {
     // 또는 @Column(columnDefinition = "MEDIUMTEXT") 또는 @Column(columnDefinition = "LONGTEXT")
     private String content;
 
+    @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LikeReply> likeReplies = new ArrayList<>();
 
-
-
+    // 좋아요 개수를 반환하는 메서드
+    public int getLikeCount() {
+        return likeReplies.size();
+    }
 
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/repository/ReplyRepository.java
@@ -2,9 +2,11 @@ package com.kernel360.ronaldo.TemuOverflow.reply.repository;
 
 import com.kernel360.ronaldo.TemuOverflow.reply.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     List<Reply> findByPostId(Long postId);
 }

--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/service/ReplyService.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/reply/service/ReplyService.java
@@ -1,11 +1,15 @@
 package com.kernel360.ronaldo.TemuOverflow.reply.service;
 
 import com.kernel360.ronaldo.TemuOverflow.post.entity.Post;
+import com.kernel360.ronaldo.TemuOverflow.reply.dto.CreateReplyRequest;
+import com.kernel360.ronaldo.TemuOverflow.reply.dto.ReplyDto;
+import com.kernel360.ronaldo.TemuOverflow.reply.dto.UpdateReplyRequest;
 import com.kernel360.ronaldo.TemuOverflow.reply.entity.Reply;
 import com.kernel360.ronaldo.TemuOverflow.reply.repository.ReplyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -16,8 +20,15 @@ public class ReplyService {
     private final ReplyRepository replyRepository;
 
     // 댓글 생성
-    public Reply createReply(Reply reply) {
-        return replyRepository.save(reply);
+    public ReplyDto createReply(Long userId, CreateReplyRequest createReplyRequest) {
+        Reply reply = Reply.builder()
+                .postId(createReplyRequest.getPostId())
+                .userId(userId)
+                .createdAt(LocalDateTime.now())
+                .content(createReplyRequest.getContent())
+                .build();
+        replyRepository.save(reply);
+        return ReplyDto.fromEntity(reply);
     }
 
     // 전체 게시글 조회
@@ -31,10 +42,11 @@ public class ReplyService {
     }
 
     // 게시글 수정
-    public Reply updateReply(Long id, Reply updatedReply) {
+    public ReplyDto updateReply(Long userId, Long id, UpdateReplyRequest updateReplyRequest) {
         Reply reply = getReplyById(id);
-        reply.setContent(updatedReply.getContent());
-        return replyRepository.save(reply);
+        reply.setContent(updateReplyRequest.getContent());
+        replyRepository.save(reply);
+        return ReplyDto.fromEntity(reply);
     }
 
     // 게시글 삭제


### PR DESCRIPTION
## 수정한 코드
- create_at, update_at 서버에서 자동으로 설정되게 수정 / 좋아요 수 반환되게 수정 / DTO 변경

## 확인해야할 사항
- 기존 코드는 FE에서 create_at과 update_at을 responseBody에 담아야했으며,
  Swagger에서 서버에서 자동으로 생성되는 Id, create_at, update_at등을 설정해줘야 했고,
  댓글, 게시글 조회시 좋아요 수도 같이 반환돼야하는데 현재 좋아요수는 반환되지 않음
- 수정 후의 코드는 create_at, update_at이 서버에서 자동 설정되게 수정할 예정이고,
  Swagger에서 FE가 편하게 API 요청할 수 있도록 DTO 수정할 예정, 
  댓글, 게시글 조회시 좋아요 수가 반환되도록 연관관계를 양방향으로 매핑할 예정


Closed #37