### PR TITLE
[Hotfix] 특정 게시글 조회할 때 solved가 정상적으로 반환되지 않는 오류 해결

### DIFF
--- a/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/service/PostService.java
+++ b/src/main/java/com/kernel360/ronaldo/TemuOverflow/post/service/PostService.java
@@ -78,6 +78,7 @@ public class PostService {
                 .userProfileImageUrl(post.getUser().getProfileImageUrl())
                 .likeCount(post.getLikeCount())
                 .isLikedByCurrentUser(isLikedByCurrentUser)
+                .isSolved(post.getIsSolved())
                 .build();
     }
 


### PR DESCRIPTION
## 수정한 코드
- 특정 게시글 조회할 때 solved가 정상적으로 반환되지 않는 오류 해결

Closed #65 